### PR TITLE
Fixed a username parsing for getting a user

### DIFF
--- a/src/classes/Users.ts
+++ b/src/classes/Users.ts
@@ -152,7 +152,8 @@ export default class Users extends Base {
    * @returns A user
    */
   public async getUser(user: number | string, options?: GetUserOptions): Promise<UserExtended> {
-    user = z.number().parse(user);
+    if(typeof user === "number") user = z.number().parse(user);
+    else user = z.string().parse(user);
     options = getUserOptionsSchema.optional().parse(options);
     let endpoint: string = `users/${user}`;
 

--- a/src/classes/Users.ts
+++ b/src/classes/Users.ts
@@ -74,6 +74,7 @@ export default class Users extends Base {
   /**
    * Makes a GET request to the `/users/{user}/kudosu` endpoint
    * @param user ID of the user to get kudosu from
+   * @param options
    * @returns An array containing the specified user's kudosu history
    */
   public async getUserKudosu(
@@ -88,6 +89,7 @@ export default class Users extends Base {
   /**
    * Makes a GET request to the `/users/{user}/recent_activity` endpoint
    * @param user ID of the user to get their recent activity from
+   * @param options
    * @returns An array containing the specified user's recent activity (each event is a union, to discriminate, use the `type` key)
    */
   public async getUserRecentActivity(
@@ -103,6 +105,7 @@ export default class Users extends Base {
    * Makes a GET request to the `/users/{user}/scores/{type}` endpoint
    * @param user ID of the user to get their scores
    * @param type Score type
+   * @param options
    * @returns An array of the specified user's scores
    */
   public async getUserScores<T extends UserScoreType>(
@@ -124,6 +127,7 @@ export default class Users extends Base {
    * Makes a GET request to the `/users/{user}/beatmapsets/{type}` endpoint
    * @param user ID of the user to get their beatmapsets
    * @param type Type of beatmapsets to return
+   * @param options
    * @returns An array of a user's beatmapsets
    */
   public async getUserBeatmaps<T extends UserBeatmapsType>(
@@ -149,11 +153,11 @@ export default class Users extends Base {
   /**
    * Makes a GET request to the `/users/{user}/{mode?}` endpoint
    * @param user ID or username of the user to get
+   * @param options
    * @returns A user
    */
   public async getUser(user: number | string, options?: GetUserOptions): Promise<UserExtended> {
-    if(typeof user === "number") user = z.number().parse(user);
-    else user = z.string().parse(user);
+    user = z.union([z.string(), z.number()]).parse(user);
     options = getUserOptionsSchema.optional().parse(options);
     let endpoint: string = `users/${user}`;
 


### PR DESCRIPTION
During production if a user tries to provide a username to get the player, it will throw a Zod error because it is trying to parse the string that user provided as a number

![image](https://github.com/L-Mario564/osu.js/assets/48449640/5470a392-cb8c-4504-b7a0-601464bddb89)
