### PR TITLE
Update userBeatmapsTypeSchema

### DIFF
--- a/docs/content/references/user-beatmaps-type.mdx
+++ b/docs/content/references/user-beatmaps-type.mdx
@@ -6,5 +6,5 @@ ref: type
 # UserBeatmapsType
 
 ```ts
-type UserBeatmapsType = 'favourite' | 'graveyard' | 'loved' | 'most_played' | 'pending' | 'ranked';
+type UserBeatmapsType = 'favourite' | 'graveyard' | 'guest' | 'loved' | 'most_played' | 'nominated' | 'pending' | 'ranked';
 ```

--- a/src/schemas/users.ts
+++ b/src/schemas/users.ts
@@ -53,8 +53,10 @@ export const getUserBeatmapsOptionsSchema = z
 export const userBeatmapsTypeSchema = z.union([
   z.literal('favourite'),
   z.literal('graveyard'),
+  z.literal('guest'),
   z.literal('loved'),
   z.literal('most_played'),
+  z.literal('nominated'),
   z.literal('pending'),
   z.literal('ranked')
 ]);


### PR DESCRIPTION
now the api allow developers to list user's guest difficulty and nominated set, this pr add these two types

only tested `guest`, but I think it works well with `nominated` too

see https://osu.ppy.sh/docs/index.html#get-user-beatmaps
