### PR TITLE
`NC`'s bitwise value is supposed to be 576

### DIFF
--- a/docs/content/references/mods-enum.mdx
+++ b/docs/content/references/mods-enum.mdx
@@ -22,6 +22,7 @@ enum ModsEnum {
   AT = 2048,
   SO = 4096,
   AP = 8192,
+  // Only set along with SuddenDeath. i.e: PF only gives 16416
   PF = 16384,
   K4 = 32768,
   K5 = 65536,

--- a/docs/content/references/mods-enum.mdx
+++ b/docs/content/references/mods-enum.mdx
@@ -16,7 +16,8 @@ enum ModsEnum {
   DT = 64,
   RX = 128,
   HT = 256,
-  NC = 512,
+  // Only set along with DoubleTime. i.e: NC only gives 576
+  NC = 576,
   FL = 1024,
   AT = 2048,
   SO = 4096,

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -81,6 +81,7 @@ export enum ModsEnum {
   AT = 2048,
   SO = 4096,
   AP = 8192,
+  // Only set along with SuddenDeath. i.e: PF only gives 16416
   PF = 16384,
   '4K' = 32768,
   '5K' = 65536,

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -75,7 +75,8 @@ export enum ModsEnum {
   DT = 64,
   RX = 128,
   HT = 256,
-  NC = 512,
+  // Only set along with DoubleTime. i.e: NC only gives 576
+  NC = 576,
   FL = 1024,
   AT = 2048,
   SO = 4096,


### PR DESCRIPTION
Nightcore is set alongside DT, so they both need their values added together
some weird osu stuff, idk.
couldn't find any other solution here, the lib I use only works if NC is 576 🤔